### PR TITLE
Hotfix(ios-video): Add ios compatibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,13 +18,13 @@
 </head>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-177217079-1"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-166095671-4"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
   gtag('js', new Date());
 
-  gtag('config', 'UA-177217079-1');
+  gtag('config', 'UA-166095671-4');
 </script>
 
 <body>

--- a/src/components/molecules/Video/Video.tsx
+++ b/src/components/molecules/Video/Video.tsx
@@ -24,6 +24,7 @@ function Video({ getDimensions }: { getDimensions: Function }) {
         if (videoRef.current) {
           const video = videoRef.current;
           video.srcObject = stream;
+          video.play();
           video.onloadedmetadata = () => {
             getDimensions([video.videoHeight, video.videoWidth], video);
           };
@@ -83,14 +84,7 @@ function Video({ getDimensions }: { getDimensions: Function }) {
       }}
       dangerouslySetInnerHTML={{
         __html: `
-          <video
-            autoplay
-            muted
-            playsinline
-          >
-            <track kind="captions" />
-            <p>Seu navegador não suporta vídeo HTML5.</p>
-          </video>
+          <video muted playsinline></video>
         `,
       }}
     />


### PR DESCRIPTION
**What i Did:**
- Remove `autoplay` property on html video tag to play only when accepted by user on safari
- Add `playsinline` property on video to play in mobile
- Changed Google Analytics id

**How to Test:**
- Try to run the analytic on web chrome and safari, then mobile chrome and safari